### PR TITLE
add pip extension + use it for installing extensions, add missing six extension

### DIFF
--- a/easybuild/easyconfigs/r/ReFrame/ReFrame-3.0.eb
+++ b/easybuild/easyconfigs/r/ReFrame/ReFrame-3.0.eb
@@ -15,9 +15,13 @@ req_py_minver = 6
 
 exts_default_options = {'source_urls': [PYPI_SOURCE]}
 
-use_pip = False
+use_pip = True
 
 exts_list = [
+    ('pip', '20.1.1', {
+        'checksums': ['27f8dc29387dd83249e06e681ce087e6061826582198a425085e0bf4c1cf3a55'],
+        'use_pip': False,
+    }),
     ('setuptools', '47.1.1', {
         'source_tmpl': 'setuptools-%(version)s.zip',
         'checksums': ['145fa62b9d7bb544fce16e9b5a9bf4ab2032d2f758b7cd674af09a92736aff74'],
@@ -44,6 +48,9 @@ exts_list = [
     ('jsonschema', '3.2.0', {
         'checksums': ['c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a'],
     }),
+    ('six', '1.15.0', {
+        'checksums': ['30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259'],
+    }),
     ('reframe', version, {
         'source_tmpl': 'v%(version)s.tar.gz',
         'source_urls': ['https://github.com/eth-cscs/reframe/archive'],
@@ -61,5 +68,8 @@ sanity_check_paths = {
 }
 
 sanity_check_commands = ['reframe -V']
+
+# need to add 'bin' subdir to $PATH explicitly to ensure right 'pip' command is used for installing extensions
+modextrapaths = {'PATH': 'bin'}
 
 moduleclass = 'devel'


### PR DESCRIPTION
@teojgo for https://github.com/easybuilders/easybuild-easyconfigs/pull/10754

This makes the installation work correctly for me when using the latest update to https://github.com/easybuilders/easybuild-easyblocks/pull/2075, both on CentOS 7.8 where both Python 2 & 3 are installed, and on CentOS 8.1 where only `python3` and `pip3` are installed (no `python`, no `pip`).