### PR TITLE
add 'external' subdirectory to $PYTHONPATH for ReFrame v3.3, since bootstrap script installs required Python packages there

### DIFF
--- a/easybuild/easyconfigs/r/ReFrame/ReFrame-3.3.eb
+++ b/easybuild/easyconfigs/r/ReFrame/ReFrame-3.3.eb
@@ -58,6 +58,10 @@ sanity_check_commands = ['reframe -V']
 sanity_pip_check = True
 
 # need to add 'bin' subdir to $PATH explicitly to ensure right 'pip' command is used for installing extensions
-modextrapaths = {'PATH': 'bin'}
+modextrapaths = {
+    'PATH': 'bin',
+    # bootstrap script installs required dependencies to 'external' subdirectory
+    'PYTHONPATH': 'external',
+}
 
 moduleclass = 'devel'


### PR DESCRIPTION
@teojgo This fixes the issues in https://github.com/easybuilders/easybuild-easyconfigs/pull/11787